### PR TITLE
Ruby 3.4+ compatibility: bigdecimal dep + h2c SSWU rename

### DIFF
--- a/bls12-381.gemspec
+++ b/bls12-381.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "h2c", "~> 0.2.0"
+  spec.add_dependency "bigdecimal"
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '>= 12.3.3'

--- a/bls12-381.gemspec
+++ b/bls12-381.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "h2c", "~> 0.2.0"
+  spec.add_dependency "h2c", ">= 0.2.1", "< 0.3"
   spec.add_dependency "bigdecimal"
 
   spec.add_development_dependency 'bundler'

--- a/lib/bls/point/g1.rb
+++ b/lib/bls/point/g1.rb
@@ -78,7 +78,7 @@ module BLS
     def self.hash_to_curve(message)
       raise PointError, 'expected hex string' unless message[/^[a-fA-F0-9]*$/]
 
-      h2c = ::H2C.get(::H2C::Suite::BLS12381G1_XMDSHA256_SWU_RO_, PointG1::DST_BASIC)
+      h2c = ::H2C.get(::H2C::Suite::BLS12381G1_XMDSHA256_SSWU_RO_, PointG1::DST_BASIC)
       p = h2c.digest([message].pack('H*'))
 
       PointG1.new(Fp.new(p.x), Fp.new(p.y), Fp::ONE)

--- a/spec/bls_spec.rb
+++ b/spec/bls_spec.rb
@@ -97,6 +97,22 @@ RSpec.describe 'bls12-381' do
         sig = BLS.sign(msg, priv, sig_type: :g1)
         expect(sig.to_hex(compressed: true )).to eq('8f7ad830632657f7b3eae17fd4c3d9ff5c13365eea8d33fd0a1a6d8fbebc5152e066bb0ad61ab64e8a8541c8e3f96de9')
       end
+
+      it 'should verify a G1 signature with a G2 public key' do
+        priv = '6f3977f6051e184b2c412daa1b5c0115ef7ab347cac8d808ffa2c26bd0658243'
+        msg = '50484522ad8aede64ec7f86b9273b7ed3940481acf93cdd40a2b77f2be2734a14012b2492b6363b12adaeaf055c573e4611b085d2e0fe2153d72453a95eaebf350ac3ba6a26ba0bc79f4c0bf5664dfdf5865f69f7fc6b58ba7d068e8'
+        sig = BLS.sign(msg, priv, sig_type: :g1)
+        pub = BLS.get_public_key(priv, key_type: :g2)
+        expect(BLS.verify(sig, msg, pub)).to be true
+      end
+
+      it 'should not verify a G1 signature against the wrong message' do
+        priv = '6f3977f6051e184b2c412daa1b5c0115ef7ab347cac8d808ffa2c26bd0658243'
+        msg = '50484522ad8aede64ec7f86b9273b7ed3940481acf93cdd40a2b77f2be2734a14012b2492b6363b12adaeaf055c573e4611b085d2e0fe2153d72453a95eaebf350ac3ba6a26ba0bc79f4c0bf5664dfdf5865f69f7fc6b58ba7d068e8'
+        sig = BLS.sign(msg, priv, sig_type: :g1)
+        pub = BLS.get_public_key(priv, key_type: :g2)
+        expect(BLS.verify(sig, '64726e3da8', pub)).to be false
+      end
     end
   end
 


### PR DESCRIPTION
Three small fixes so the gem loads, resolves dependencies correctly, and verifies signatures on current Ruby.

## 1. Add `bigdecimal` to runtime deps

Ruby 3.4 removed `bigdecimal` from default gems. `lib/bls/point.rb` requires it at runtime, so on Ruby 3.4+ the gem fails to load with:

    cannot load such file -- bigdecimal

## 2. Require `h2c >= 0.2.1` for the `SSWU_RO_` suite constant

The `~> 0.2.0` pin let Bundler resolve to h2c 0.2.1, which renamed `BLS12381G1_XMDSHA256_SWU_RO_` to `BLS12381G1_XMDSHA256_SSWU_RO_` (the correct name per RFC 9380: SSWU = Simplified SWU). That rename is what broke the gem at load time. Tightening to `>= 0.2.1, < 0.3` makes the dependency explicit about the version it needs.

## 3. Use the new `SSWU_RO_` constant name

`lib/bls/point/g1.rb:81` still referenced the old name, so any verify call through `PointG1.hash_to_curve` raised `NameError`.
Updated to the current name.

## 4. Spec coverage for `BLS.verify` with G1 signature + G2 public key

Adds two specs in the existing `G2 public key and G1 signature` context (one positive, one negative), covering the `PointG1.hash_to_curve` path.

## Verification

Full suite passes on Ruby 3.4.3 (111 examples, 0 failures).
Also verified against real drand quicknet signatures.